### PR TITLE
Fix: on quote deletion - delete all quote's dangling tags

### DIFF
--- a/smash/views.py
+++ b/smash/views.py
@@ -131,6 +131,10 @@ def moderate():
 
     elif request.form['submit'] == "Delete":
         quote = Quote.query.filter_by(id=request.form['quoteid']).first()
+        # Delete dangling tags (alive only with current Quote)
+        dangling_tags = [tag for tag in quote.tags if tag.quotes.count() == 1]
+        for tag in dangling_tags:
+            db.session.delete(tag)
         db.session.delete(quote)
         db.session.commit()
 


### PR DESCRIPTION
Introduces:
-  deleting quote, deletes tags if they're the only tags left.

As discussed in #6 maybe `collapse` could help, yet only options are `delete`, which deletes regardless, and `delete-orphan`, which requires `single_parent` and it's not the case in this application.